### PR TITLE
Update CommandLineToolsConfig.NupkgVersion to 2025.3

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-13, windows-latest ]
+        os: [ ubuntu-22.04, macos-15-intel, windows-latest ]
 
     runs-on: ${{ matrix.os }}
 

--- a/JetBrains.Profiler.SelfApi/src/Impl/CommandLineToolsConfig.cs
+++ b/JetBrains.Profiler.SelfApi/src/Impl/CommandLineToolsConfig.cs
@@ -5,7 +5,7 @@
     // The version (major and minor only!!!) of JetBrains.dotTrace.CommandLineTools and JetBrains.dotMemory.Console
     // NuGet-packages that must be downloaded.
     // Don't forget to update xmldoc. The xmldoc is used for injecting proper version into Init methods (inheritdoc).
-    /// <summary>2023.1</summary>
-    internal static readonly NuGet.SemanticVersion NupkgVersion = new(2024, 1);
+    /// <summary>2025.3</summary>
+    internal static readonly NuGet.SemanticVersion NupkgVersion = new(2025, 3);
   }
 }


### PR DESCRIPTION
Several serious issues were fixed since 2023.1:

- https://youtrack.jetbrains.com/issue/PROF-1571 (required for https://youtrack.jetbrains.com/issue/VSRS-661)
- https://youtrack.jetbrains.com/issue/DTRC-28528
- several security issues related to Timeline profiling on Windows

So, we should update to the fresh CLT version with fixes for the aforementioned issues.