### PR TITLE
Update JetBrains.Profiler.SelfApi to net8.0

### DIFF
--- a/JetBrains.Profiler.SelfApi/src/JetBrains.Profiler.SelfApi.csproj
+++ b/JetBrains.Profiler.SelfApi/src/JetBrains.Profiler.SelfApi.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net46;net8.0</TargetFrameworks>
     <RootNamespace>JetBrains.Profiler.SelfApi</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>true</SignAssembly>
@@ -41,4 +41,5 @@ Supported frameworks:
     <Reference Condition="'$(TargetFramework)' == 'net46'" Include="System.IO.Compression" />
     <Reference Condition="'$(TargetFramework)' == 'net46'" Include="System.Net.Http" />
   </ItemGroup>
+
 </Project>

--- a/JetBrains.Profiler.SelfApi/tests/JetBrains.Profiler.SelfApi.Tests.csproj
+++ b/JetBrains.Profiler.SelfApi/tests/JetBrains.Profiler.SelfApi.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp3.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>net46;net8.0</TargetFrameworks>
     <RootNamespace>JetBrains.Profiler.SelfApi.Tests</RootNamespace>
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
netcoreapp3.0 support ended in March 2020, 6 years ago. I don't think it's worth supporting TFMs that are already out of support.